### PR TITLE
feat: make red links use native confirm to go out to MDN

### DIFF
--- a/components/layoutHeader.tsx
+++ b/components/layoutHeader.tsx
@@ -9,8 +9,9 @@ import classNames from 'classnames';
 export default function LayoutHeader() {
   const router = useRouter();
   const currentRoute = router.asPath;
-  const nav: { path: string; title: string }[] = process.env
-    .mainNav as unknown as {
+  const nav: { path: string; title: string }[] = JSON.parse(
+    process.env.mainNav
+  ) as {
     path: string;
     title: string;
   }[];

--- a/components/translationStatusRow.tsx
+++ b/components/translationStatusRow.tsx
@@ -1,5 +1,8 @@
 import { ContentItem } from '../content/wdContentLoader';
 import classNames from 'classnames';
+
+import getMdnUrl from '../utils/get-mdn-url';
+import CopyToClipboard from './copyToClipboard';
 import {
   GithubIcon,
   GlobeIcon,
@@ -7,7 +10,6 @@ import {
   TerminalIcon,
   FileCodeIcon,
 } from './icons';
-import CopyToClipboard from './copyToClipboard';
 
 interface Params {
   page: Partial<ContentItem & { popularity: number }>;
@@ -62,9 +64,7 @@ export default function TranslationStatusRow({
 
   const noteOnUpdate = `Оригінальний вміст: [${escapeHtml(
     title
-  )}@MDN](https://developer.mozilla.org/en-us/docs/${
-    page.slug
-  }), [сирці ${escapeHtml(
+  )}@MDN](${getMdnUrl(page.slug)}), [сирці ${escapeHtml(
     title
   )}@GitHub](https://github.com/mdn/content/blob/main/files/en-us${
     page.originalPath
@@ -136,7 +136,7 @@ export default function TranslationStatusRow({
           <a
             className="text-ui-typo px-2"
             title="Переглянути оригінальний текст на MDN"
-            href={`https://developer.mozilla.org/en-us/docs/${page.slug}`}
+            href={getMdnUrl(page.slug)}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -160,7 +160,7 @@ export default function TranslationStatusRow({
               <CopyToClipboard
                 text={noteOnUpdate}
                 className={'px-2'}
-                title={'Cкопіювати перелік комітів зі змінами'}
+                title={'Скопіювати перелік комітів зі змінами'}
               >
                 <CopyIcon size={1.7} />
               </CopyToClipboard>
@@ -168,7 +168,7 @@ export default function TranslationStatusRow({
               <CopyToClipboard
                 text={gitDiffCommand}
                 className={'px-2'}
-                title={'Cкопіювати команду Git для перегляду всіх змін'}
+                title={'Скопіювати команду Git для перегляду всіх змін'}
               >
                 <FileCodeIcon size={1.7} />
               </CopyToClipboard>
@@ -181,7 +181,7 @@ export default function TranslationStatusRow({
                 text={bashCommand}
                 className={'px-2'}
                 title={
-                  'Cкопіювати bash скрипт для ініціалізації файлу перекладу (скопіювати і виконати в корені репозиторію)'
+                  'Скопіювати bash скрипт для ініціалізації файлу перекладу (скопіювати і виконати в корені репозиторію)'
                 }
               >
                 <TerminalIcon size={1.7} />
@@ -190,7 +190,7 @@ export default function TranslationStatusRow({
               <CopyToClipboard
                 text={noteOnUpdate}
                 className={'px-2'}
-                title={'Cкопіювати заголовок для коміт-повідомлення'}
+                title={'Скопіювати заголовок для коміт-повідомлення'}
               >
                 <CopyIcon size={1.7} />
               </CopyToClipboard>

--- a/components/wdNavItem.tsx
+++ b/components/wdNavItem.tsx
@@ -1,5 +1,8 @@
 import classNames from 'classnames';
 import Link from 'next/link';
+import type { MouseEventHandler } from 'react';
+
+import confirmMdnNavigation from '../utils/confirm-mdn-navigation';
 
 export interface LinkItem {
   path: string;
@@ -10,14 +13,21 @@ export interface LinkItem {
 
 interface Params {
   isCurrent: boolean;
+  isMissing: boolean;
   page: LinkItem;
 }
-
-export default function WdNavItem({ page, isCurrent }: Params) {
+export default function WdNavItem({ isCurrent, isMissing, page }: Params) {
+  const handleClick: MouseEventHandler<HTMLAnchorElement> = isMissing
+    ? (event) => {
+        event.preventDefault();
+        confirmMdnNavigation(page.path);
+      }
+    : null;
   return (
     <Link
       href={page.path}
       className="flex items-center py-1 relative text-ui-typo no-underline"
+      onClick={handleClick}
       passHref
     >
       <span

--- a/components/wdNavMenu.tsx
+++ b/components/wdNavMenu.tsx
@@ -41,7 +41,11 @@ export default function WdNavMenu({ supSection }: Params) {
                 !link.hasLocalizedContent ? MISSING_TRANSLATION_MESSAGE : ''
               }
             >
-              <WdNavItem page={link} isCurrent={link.isCurrent} />
+              <WdNavItem
+                page={link}
+                isCurrent={link.isCurrent}
+                isMissing={!link.hasLocalizedContent}
+              />
             </li>
           ))}
         </ul>
@@ -79,7 +83,11 @@ export default function WdNavMenu({ supSection }: Params) {
                           : ''
                       }
                     >
-                      <WdNavItem page={page} isCurrent={page.isCurrent} />
+                      <WdNavItem
+                        page={page}
+                        isCurrent={page.isCurrent}
+                        isMissing={!page.hasLocalizedContent}
+                      />
                     </li>
                   ))}
                 </ul>

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,12 @@
 module.exports = {
   env: {
-    mainNav: [
+    mainNav: JSON.stringify([
       {
         path: '/uk/docs/Web/',
         title: 'Технології',
       },
       { path: '/docs/', title: 'Про проєкт' },
-    ],
+    ]),
     licenseLink: '/docs/licensing/',
     ourGithub: 'https://github.com/webdoky',
   },

--- a/utils/confirm-mdn-navigation.ts
+++ b/utils/confirm-mdn-navigation.ts
@@ -1,0 +1,10 @@
+import getMdnUrl from './get-mdn-url';
+
+const CONFIRMATION_QUESTION =
+  'Це посилання веде до статті, яку ми ще не переклали. Відкрити варіант англійською на MDN?';
+
+export default function confirmMdnNavigation(path: string) {
+  if (confirm(CONFIRMATION_QUESTION)) {
+    window.open(getMdnUrl(path), '_blank');
+  }
+}

--- a/utils/get-mdn-url.ts
+++ b/utils/get-mdn-url.ts
@@ -1,0 +1,13 @@
+const MDN_URL_PREFIX = 'https://developer.mozilla.org/en-US/docs/';
+
+export default function getMdnUrl(path: string) {
+  console.log('getMndUrl', path);
+  // Remove leading slash, if any
+  let trimmedPath = path.replace(/^\//, '');
+  // Remove hash part, if any
+  trimmedPath = trimmedPath.split('#')[0];
+  if (trimmedPath.startsWith(`uk/docs/`)) {
+    trimmedPath = trimmedPath.replace(`uk/docs/`, '');
+  }
+  return `${MDN_URL_PREFIX}${trimmedPath}`;
+}


### PR DESCRIPTION
- not-translated links open native confirm modal to go straight to MDN (on new tab, of course)
- internal links use next router navigation – as a bonus